### PR TITLE
Update tlv.cpp

### DIFF
--- a/libndef/tlv.cpp
+++ b/libndef/tlv.cpp
@@ -125,7 +125,7 @@ TlvList Tlv::fromByteArray(const QByteArray& data, quint64 offset)
             {
                 if ((count - index) > 0)
                 {
-                    quint16 length = buffer.at(index);
+                    quint16 length = (quint8)buffer.at(index);
                     ++index;
 
                     if (length > 0xFE)


### PR DESCRIPTION
Missing cast to unsigned type; added it to avoid problem with a value greater than 127.