### PR TITLE
Fixes the build by adding missing includes to ndef-decode.cpp.

### DIFF
--- a/tools/ndef-decode.cpp
+++ b/tools/ndef-decode.cpp
@@ -17,6 +17,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
+#include <QTextStream>
+#include <QFile>
+#include <QDataStream>
+
 #include <QtCore/QCoreApplication>
 #include <QDebug>
 #include <QStringList>


### PR DESCRIPTION
As documented four years ago in #3, G++ fails to build `ndef-decode.cpp` because of missing header files.

```
make[2]: Entering directory '/home/travis/svn/libndef/tools'
g++ -c -pipe -O2 -Wall -W -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_CORE_LIB -I. -I../include -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -I. -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o ndef-decode.o ndef-decode.cpp
ndef-decode.cpp: In function ‘void decodeNDEFMessage(QByteArray, int)’:
ndef-decode.cpp:92:44: error: variable ‘QDataStream stream’ has initializer but incomplete type
                         QDataStream stream(record.payload());
                                            ^~~~~~
ndef-decode.cpp:107:21: warning: this statement may fall through [-Wimplicit-fallthrough=]
                     if (output.isOpen())
                     ^~
ndef-decode.cpp:112:17: note: here
                 default:
                 ^~~~~~~
```

This PR simply adds the missing headers.

```diff
diff --git a/tools/ndef-decode.cpp b/tools/ndef-decode.cpp
index 68c0d9a..9235512 100644
--- a/tools/ndef-decode.cpp
+++ b/tools/ndef-decode.cpp
@@ -17,6 +17,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
+#include <QTextStream>
+#include <QFile>
+#include <QDataStream>
+
 #include <QtCore/QCoreApplication>
 #include <QDebug>
 #include <QStringList>
```

I've changed nothing else, so this should be clean to merge.